### PR TITLE
Update gradle version to 3.2.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         // Matches the RN Hello World template
         // https://github.com/facebook/react-native/blob/1e8f3b11027fe0a7514b4fc97d0798d3c64bc895/local-cli/templates/HelloWorld/android/build.gradle#L8
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.2.0'
     }
 }
 


### PR DESCRIPTION
Usage in Android Studio is flagging a warning that we must upgrade the Android Gradle Plugin as the minimum supported version is 3.2.0.

![image](https://user-images.githubusercontent.com/32134629/169087177-6e25a533-cc61-4f04-814b-65c9f25bb1c2.png)
